### PR TITLE
Fixes for using @Attach macro in local mode

### DIFF
--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -67,6 +67,7 @@ object JuliaRDD extends Logging {
 
       // Create and start the worker
       val pb = new ProcessBuilder(Seq("julia", "-e", "using Spark; using Iterators; Spark.launch_worker()"))
+      pb.directory(new File(SparkFiles.getRootDirectory()))
       // val workerEnv = pb.environment()
       // workerEnv.putAll(envVars)
       val worker = pb.start()

--- a/src/attach.jl
+++ b/src/attach.jl
@@ -7,20 +7,25 @@ get_attachments() = ATTACHMENT_BUFFER[]
 clear_attachments!() = ATTACHMENT_BUFFER[] = Expr[]
 
 function process_attachments(sc::SparkContext)
-    mktempdir() do dirpath
-        for ex in get_attachments()
-            LAST_ATTACHMENT_IDX[] = LAST_ATTACHMENT_IDX[] + 1
-            attachment_idx = @sprintf "%08d" LAST_ATTACHMENT_IDX[]
-            path = joinpath(dirpath, "attached_" * attachment_idx * ".jl")
-            open(path, "w") do io
-                write(io, string(ex))
-            end
-            add_file(sc, path)
-            # if it's `include` expression, also attach included file
-            if isa(ex, Expr) && ex.head == :call && ex.args[1] == :include
-                add_file(sc, ex.args[2])
-            end
-         end
+    for ex in get_attachments()
+        LAST_ATTACHMENT_IDX[] = LAST_ATTACHMENT_IDX[] + 1
+        attachment_idx = @sprintf "%08d" LAST_ATTACHMENT_IDX[]
+        path = joinpath(get_temp_dir(sc), "attached_" * attachment_idx * ".jl")
+        open(path, "w") do io
+            write(io, string(ex))
+        end
+        # add_file wants URI format in order to work in local mode
+        # and it does seem to work unless we have three slashes at the statr
+        if is_windows()
+            path = "file:///" * replace(path, r"\\", s"/")
+        else
+            path = "file://" * path
+        end
+        add_file(sc, path)
+        # if it's `include` expression, also attach included file
+        if isa(ex, Expr) && ex.head == :call && ex.args[1] == :include
+            add_file(sc, ex.args[2])
+        end
     end
     clear_attachments!()
 end

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -79,7 +79,12 @@ function launch_worker()
         # info("Julia: exiting")
     catch e
         # TODO: handle the case when JVM closes connection
-        Base.show_backtrace(STDERR, catch_backtrace())
+        io = IOBuffer()
+        Base.show_backtrace(io, catch_backtrace())
+        seekstart(io)
+        bt = readall(io)
+        info(bt)
+        write(STDERR, bt)
         writeint(sock, JULIA_EXCEPTION_THROWN)
         rethrow()
     end

--- a/test/attach.jl
+++ b/test/attach.jl
@@ -1,0 +1,12 @@
+# tests the attach macro
+@attach a = 2
+@attach include("attach_include.jl")
+
+# test of basic funtionality
+sc = SparkContext(master="local")
+txt = parallelize(sc, ["hello", "world"])
+rdd = map_partitions(txt, it -> map(func, it))
+
+@test reduce(rdd, +) == 14
+
+close(sc)

--- a/test/attach_include.jl
+++ b/test/attach_include.jl
@@ -1,0 +1,3 @@
+function func(s)
+    length(s) + a
+end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,0 +1,10 @@
+# test of basic funtionality
+sc = SparkContext(master="local")
+txt = parallelize(sc, ["hello", "world"])
+rdd = map_partitions(txt, it -> map(s -> length(s), it))
+
+@test count(rdd) == 2
+@test reduce(rdd, +) == 10
+
+close(sc)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,5 @@
 using Spark
 using Base.Test
 
-# write your own tests here
-sc = SparkContext(master="local")
-txt = parallelize(sc, ["hello", "world"])
-rdd = map_partitions(txt, it -> map(s -> length(s), it))
-
-@test count(rdd) == 2
-@test reduce(rdd, +) == 10
-
-close(sc)
+include("basic.jl")
+include("attach.jl")


### PR DESCRIPTION
The previous issues when using the attach macros in local mode seem to have been caused by 2 issues:
In local mode the files seems not to be copied at point of creation and so the lifetime of the temporary folder needs to be extended, This is fixed by attaching the temporary directory to the context which has the correct lifetime.
The working directory of the worker wasn't set to the spark working dir in local mode
Also:
- added stacktrace to spark log which helps diagnosing worker issues
- added a test of both simple attach and include
