### PR TITLE
Fix for issues with reduce when there is no map stage

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -33,7 +33,7 @@ end
 
 function clear_up_tempdir(sc::SparkContext)
     if sc.tempdir != ""
-        rm(sc.tempdir, true)
+        rm(sc.tempdir, recursive=true)
     end
 end
 

--- a/src/rdd.jl
+++ b/src/rdd.jl
@@ -143,7 +143,7 @@ end
 "Reduce elements of `rdd` using specified function `f`"
 function reduce(rdd::RDD, f::Function)
     process_attachments(context(rdd))
-    locally_reduced = map_partitions(rdd, it -> reduce(f, it))
+    locally_reduced = map_partitions(rdd, it -> [reduce(f, it)])
     subresults = collect(eltype(rdd), locally_reduced)
     return reduce(f, subresults)
 end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,0 +1,8 @@
+# test of reduce with no map stage
+sc = SparkContext(master="local")
+txt = parallelize(sc, ["hello", "world"])
+
+@test reduce(txt, *) == "helloworld"
+
+close(sc)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Base.Test
 
 include("basic.jl")
 include("attach.jl")
+include("reduce.jl")


### PR DESCRIPTION
Fixes problems with reduce.  

Variant of issue can be seen using following lines in REPL
```
using Spark
sc = SparkContext(master="local")
rdd = parallelize(sc, ["Hello", "World"])
reduce(rdd, *)
```
without fix gives result consistent with operator being applied to each character of the string rather than operating on the strings.
Also fixes issues when calling reduce on custom types where errors due to missing start occur.