### PR TITLE
Minor fixes for Spark_Context

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -13,10 +13,10 @@ Params:
             are supported. Default is 'local'
  * appname - name of application
 """
-function SparkContext(;master::AbstractString="",
+function SparkContext(;master::AbstractString="local",
                       appname::AbstractString="Julia App on Spark")
     conf = SparkConf()
-    if (master != "") setmaster(conf, master) end
+    setmaster(conf, master)
     setappname(conf, appname)
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)
     sc = SparkContext(jsc, appname, "")

--- a/src/context.jl
+++ b/src/context.jl
@@ -2,6 +2,7 @@
 "Wrapper around JavaSparkContext"
 type SparkContext
     jsc::JJavaSparkContext
+    appname::AbstractString
     tempdir::AbstractString
 end
 
@@ -18,14 +19,15 @@ function SparkContext(;master::AbstractString="",
     if (master != "") setmaster(conf, master) end
     setappname(conf, appname)
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)
-    sc = SparkContext(jsc, "")
+    sc = SparkContext(jsc, appname, "")
     add_jar(sc, joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1.jar"))
     finalizer(sc, clear_up_tempdir)
     return sc
 end
 
 function SparkContext(jsc::JJavaSparkContext)
-    sc = SparkContext(jsc, "")
+    appname = jcall(jsc, "appName", JString, ())
+    sc = SparkContext(jsc, appname, "")
     finalizer(sc, clear_up_tempdir)
     return sc
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -2,6 +2,7 @@
 "Wrapper around JavaSparkContext"
 type SparkContext
     jsc::JJavaSparkContext
+    master::AbstractString
     appname::AbstractString
     tempdir::AbstractString
 end
@@ -19,7 +20,7 @@ function SparkContext(;master::AbstractString="local",
     setmaster(conf, master)
     setappname(conf, appname)
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)
-    sc = SparkContext(jsc, appname, "")
+    sc = SparkContext(jsc, master, appname, "")
     add_jar(sc, joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1.jar"))
     finalizer(sc, clear_up_tempdir)
     return sc
@@ -27,7 +28,8 @@ end
 
 function SparkContext(jsc::JJavaSparkContext)
     appname = jcall(jsc, "appName", JString, ())
-    sc = SparkContext(jsc, appname, "")
+    master = jcall(jsc, "master", JString, ())
+    sc = SparkContext(jsc, master, appname, "")
     finalizer(sc, clear_up_tempdir)
     return sc
 end
@@ -47,7 +49,7 @@ function get_temp_dir(sc::SparkContext)
 end
 
 function Base.show(io::IO, sc::SparkContext)
-    print(io, "SparkContext($(sc.appname))")
+    print(io, "SparkContext($(sc.master),$(sc.appname))")
 end
 
 

--- a/src/rdd.jl
+++ b/src/rdd.jl
@@ -153,7 +153,7 @@ function context(rdd::RDD)
     ssc = jcall(rdd.jrdd, "context", JSparkContext, ())
     jsc = jcall(JJavaSparkContext, "fromSparkContext",
                 JJavaSparkContext, (JSparkContext,), ssc)
-    return SparkContext(jsc, "")  # TODO: get name
+    return SparkContext(jsc)
 end
 
 """


### PR DESCRIPTION
Fixes errors shown in REPL with SparkContext due to show function using removed appname
Restored appname to SparkContext
Added master to SparkContext state and show
Added default value for master to make behaviour consistent with comments.
