### PR TITLE
implement filter

### DIFF
--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -227,7 +227,7 @@ object JuliaRDD extends Logging {
 }
 
 class JuliaPairRDD(@transient parent: RDD[_],command: Array[Byte]) extends AbstractJuliaRDD[(Any, Any)](parent, command) {
-  def asJavaRDD(): JavaPairRDD[Any, Any] = {
+  def asJavaPairRDD(): JavaPairRDD[Any, Any] = {
     JavaPairRDD.fromRDD(this)
   }
 }

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,7 +1,7 @@
 
 using JavaCall
 using Iterators
-import Base: map, reduce, count, collect, close
+import Base: map, reduce, count, collect, close, filter
 
 JSparkConf = @jimport org.apache.spark.SparkConf
 JSparkContext = @jimport org.apache.spark.SparkContext

--- a/src/rdd.jl
+++ b/src/rdd.jl
@@ -177,6 +177,16 @@ function flat_map_pair(rdd::RDD, f::Function)
     return PipelinedPairRDD(rdd, create_flat_map_function(f))
 end
 
+function create_filter_function(f::Function)
+    function func(idx, it)
+        filter(f, it)
+    end
+    return func
+end
+
+filter(rdd::SingleRDD, f::Function) = PipelinedRDD(rdd, create_filter_function(f))
+filter(rdd::PairRDD, f::Function) = PipelinedPairRDD(rdd, create_filter_function(f))
+
 "Reduce elements of `rdd` using specified function `f`"
 function reduce(rdd::RDD, f::Function)
     process_attachments(context(rdd))

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -1,0 +1,17 @@
+# test filter
+sc = SparkContext(master="local")
+
+nums1 = parallelize(sc, 1:30)
+n2 = filter(nums1, x->(x>10))
+n3 = filter(n2, x->(x<15))
+
+@test count(n2) == 20
+@test count(n3) == 4
+
+pnums1 = cartesian(nums1, nums1)
+pn2 = filter(pnums1, x->(x[1]>10 && x[2]<10))
+pn3 = filter(pnums1, x->(x[1]<15 && x[2]>5))
+@test count(pn2) == 180
+@test count(pn3) == 350
+
+close(sc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,4 +11,4 @@ include("cartesian.jl")
 include("group_by_key.jl")
 include("reduce_by_key.jl")
 include("repartition_coalesce.jl")
-
+include("filter.jl")


### PR DESCRIPTION
Implemented filter.

Also fixed a typo bug that caused error in `as_java_rdd` function for pair RDDs.
Function `asJavaRDD` in `class JuliaPairRDD` should have been named `asJavaPairRDD`.