### PR TITLE
ability to set custom config values

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -15,8 +15,8 @@ Params:
  * appname - name of application
 """
 function SparkContext(;master::AbstractString="local",
-                      appname::AbstractString="Julia App on Spark")
-    conf = SparkConf()
+                      appname::AbstractString="Julia App on Spark",
+                      conf::SparkConf=SparkConf())
     setmaster(conf, master)
     setappname(conf, appname)
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)


### PR DESCRIPTION
A minor, backwards compatible, api change that allows for setting custom properties into the `SparkConfig` object, and passing that in to the `SparkContext`