### PR TITLE
fix error handling

### DIFF
--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -161,9 +161,11 @@ object JuliaRDD extends Logging {
       case SpecialLengths.JULIA_EXCEPTION_THROWN =>
         // Signals that an exception has been thrown in julia
         val exLength = stream.readInt()
-        val obj = new Array[Byte](exLength)
+        val strlength = -exLength + SpecialLengths.STRING_START
+        val obj = new Array[Byte](strlength)
         stream.readFully(obj)
-        throw new Exception(new String(obj, Charsets.UTF_8))
+        val str = new String(obj, Charsets.UTF_8)
+        throw new Exception(str)
       case SpecialLengths.ARRAY_VALUE =>
         val ab = new collection.mutable.ArrayBuffer[Any]()
         while(typeLength == SpecialLengths.ARRAY_VALUE) {
@@ -189,7 +191,7 @@ object JuliaRDD extends Logging {
           throw new RuntimeException("Protocol error")
         }
     }
-    
+
   }
 
   def readRDDFromFile(sc: JavaSparkContext, filename: String, parallelism: Int): JavaRDD[Any] = {
@@ -220,7 +222,7 @@ object JuliaRDD extends Logging {
     dataStream.flush()
     byteArrayOut.toByteArray()
   }
-  
+
   def collectToJulia(rdd: JavaRDD[Any]): Array[Byte] = {
     collectToByteArray[Any](rdd.collect())
   }

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -74,7 +74,7 @@ function writeobj(io::IO, x::Integer)
 end
 
 function load_stream(io::IO)
-    function it()        
+    function it()
         code, _next = readobj(io)
         while code != END_OF_DATA_SECTION
             produce(_next)
@@ -103,17 +103,15 @@ end
 
 function launch_worker()
     include_attached()
-    port = parse(Int, readline(STDIN))    
+    port = parse(Int, readline(STDIN))
     sock = connect("127.0.0.1", port)
     try
         split = readint(sock)
-        # info("Julia: starting partition id: $split")
         func = readobj(sock)[2]
         it = load_stream(sock)
         dump_stream(sock, func(split, it))
         writeint(sock, END_OF_DATA_SECTION)
         writeint(sock, END_OF_STREAM)
-        # info("Julia: exiting")
     catch e
         # TODO: handle the case when JVM closes connection
         io = IOBuffer()
@@ -121,8 +119,7 @@ function launch_worker()
         seekstart(io)
         bt = readall(io)
         info(bt)
-        write(STDERR, bt)
         writeint(sock, JULIA_EXCEPTION_THROWN)
-        rethrow()
+        writeobj(sock, string(e) * bt)
     end
 end


### PR DESCRIPTION
With this change, errors thrown on the Julia side are now passed back to the driver. Before this change, the exception was not being passed from Julia correctly. 