### PR TITLE
clean up files at exit, do not use finalizer

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -22,7 +22,6 @@ function SparkContext(;master::AbstractString="local",
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)
     sc = SparkContext(jsc, master, appname, "")
     add_jar(sc, joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1.jar"))
-    finalizer(sc, clear_up_tempdir)
     return sc
 end
 
@@ -30,20 +29,14 @@ function SparkContext(jsc::JJavaSparkContext)
     appname = jcall(jsc, "appName", JString, ())
     master = jcall(jsc, "master", JString, ())
     sc = SparkContext(jsc, master, appname, "")
-    finalizer(sc, clear_up_tempdir)
     return sc
-end
-
-
-function clear_up_tempdir(sc::SparkContext)
-    if sc.tempdir != ""
-        rm(sc.tempdir, recursive=true)
-    end
 end
 
 function get_temp_dir(sc::SparkContext)
     if sc.tempdir == ""
         sc.tempdir = mktempdir()
+        x = deepcopy(sc.tempdir)
+        atexit(()->rm(x, recursive=true))
     end
     return sc.tempdir
 end


### PR DESCRIPTION
The attach functionality is written to hang off a `SparkContext`. The directory name is stored within the `sc`, and the directory is cleaned up from the finalizer of the `sc`.  

While top level driver code creates a single `SparkContext` and keeps using it, the actual transfer happens when a `reduce(rdd, f)` is called. Since that call does not take a `sc` as a parameter, it is retrieved from the java side, and a new object is created in Julia. This is a function local object, and is soon garbage collected, often before the session finishes. 

This PR changes the clean up to a `atexit` hook rather than the finalizer. Thus the files are deleted when Julia exits. This might create some duplicate files, but that seems harmless, and everything gets eventually cleaned up. 

The alternate would be to store a reference to the `SparkContext` in a member variable in all `RDD` type objects in Julia. Then the `context(rdd:RDD)` function can simply written as `return rdd.sc`. However, this will have to be done for all the different `RDD` types and handled in all their constructors. 