### PR TITLE
Enable yarn mode

### DIFF
--- a/examples/InstallJuliaEMR.sh
+++ b/examples/InstallJuliaEMR.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# install julia
+curl -s https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.1-linux-x86_64.tar.gz | sudo tar -xz -C /usr/local/
+JULIA_DIR=/usr/local/julia-6445c82d00
+
+# install maven
+curl -s http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.2-bin.tar.gz | sudo tar -xz -C /usr/local/
+MAVEN_DIR=/usr/local/apache-maven-3.2.2
+export PATH=$MAVEN_DIR/bin:$PATH
+
+# set environment variables
+declare -a users=("hadoop" "ec2-user")
+for usr in "${users[@]}"; do
+   ENV_FILE=/home/${usr}/.bashrc
+   sudo echo "" >> ${ENV_FILE}
+   sudo echo "export JAVA_HOME=/usr/lib/jvm/java" >> ${ENV_FILE}
+   sudo echo "export SPARK_HOME=/usr/lib/spark/" >> ${ENV_FILE}
+   sudo echo "export HADOOP_CONF_DIR=/etc/hadoop/conf" >> ${ENV_FILE}
+   sudo echo "export YARN_CONF_DIR=/etc/hadoop/conf" >> ${ENV_FILE}
+   sudo echo "export PATH=${PATH}:${MAVEN_DIR}/bin:${JULIA_DIR}/bin" >> ${ENV_FILE} 
+   sudo echo "export SPARK_CONF_DIR=/etc/spark/conf.dist/" >> ${ENV_FILE}
+   sudo echo "spark.executorEnv.JULIA_HOME ${JULIA_DIR}/bin" >> ${SPARK_CONF_DIR}/spark-defaults.conf
+   sudo echo "spark.executorEnv.JULIA_PKGDIR ${JULIA_PKGDIR}" >> ${SPARK_CONF_DIR}/spark-defaults.conf
+   sudo echo "spark.executorEnv.JULIA_VERSION v0.6" >> ${SPARK_CONF_DIR}/spark-defaults.conf
+done
+
+export SPARKJL_PROFILE=yarn
+
+# setup spark julia binding
+$JULIA_DIR/bin/julia -e 'Pkg.add("Spark");Pkg.checkout("Spark");Pkg.build("Spark"); using Spark;'

--- a/examples/InstallJuliaHDI.sh
+++ b/examples/InstallJuliaHDI.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# An example shell script that can be used on Azure HDInsight to install Julia to HDI Spark cluster
+# This script, or a derivative should be set as a script action when deploying an HDInsight cluster
+
+# install julia v0.6
+curl -s https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.0-linux-x86_64.tar.gz | sudo tar -xz -C /usr/local/
+JULIA_HOME=/usr/local/julia-903644385b/bin
+
+# install maven
+curl -s http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.2-bin.tar.gz | sudo tar -xz -C /usr/local/
+export M2_HOME=/usr/local/apache-maven-3.2.2
+export PATH=$M2_HOME/bin:$PATH
+
+# Create Directories
+export JULIA_PKGDIR="/home/hadoop/.julia/"
+mkdir -p ${JULIA_PKGDIR}
+
+# Set Environment variables for current session
+export PATH=${PATH}:${MVN_HOME}/bin:${JULIA_HOME}/bin
+export HOME="/root"
+echo "Installing Julia Packages in Julia Folder ${JULIA_PKGDIR}"
+#Install Spark.jl
+$JULIA_HOME/julia -e 'Pkg.add("Spark");Pkg.checkout("Spark");Pkg.build("Spark"); using Spark;'
+declare -a users=("spark" "yarn" "hadoop" "sshuser") #TODO: change accordingly
+SPARK_HOME=/usr/hdp/current/spark2-client
+for cusr in "${users[@]}"; do
+   echo " Adding vars for ser ${cusr}"
+   echo "" >> /home/${cusr}/.bashrc
+   echo "export MVN_HOME=/usr/local/apache-maven-3.2.2" >> /home/${cusr}/.bashrc
+   echo "export PATH=${PATH}:${MVN_HOME}/bin:${JULIA_HOME}" >> /home/${cusr}/.bashrc   
+   echo "export YARN_CONF_DIR=/etc/hadoop/conf" >> /home/${cusr}/.bashrc
+   echo "export JULIA_HOME=${JULIA_HOME}" >> /home/${cusr}/.bashrc
+   echo "export JULIA_PKGDIR=${JULIA_PKGDIR}" >> /home/${cusr}/.bashrc   
+   echo "source ${SPARK_HOME}/bin/load-spark-env.sh" >> /home/${cusr}/.bashrc 
+   echo "spark.executorEnv.JULIA_HOME ${JULIA_HOME}" >> ${SPARK_HOME}/conf/spark-defaults.conf
+   echo "spark.executorEnv.JULIA_PKGDIR ${JULIA_PKGDIR}" >> ${SPARK_HOME}/conf/spark-defaults.conf
+   echo "spark.executorEnv.JULIA_VERSION v0.6" >> ${SPARK_HOME}/conf/spark-defaults.conf
+   # Set Package folder permissions   
+   setfacl -R -m u:${cusr}:rwx ${JULIA_PKGDIR};  
+done

--- a/jvm/sparkjl/pom.xml
+++ b/jvm/sparkjl/pom.xml
@@ -60,6 +60,10 @@
       <url>http://repo.akka.io/releases</url>
     </repository>
     <repository>
+      <id>Twitter repository</id>
+      <url>http://maven.twttr.com/</url>
+    </repository>
+    <repository>
         <id>scala</id>
         <name>Scala Tools</name>
         <url>http://scala-tools.org/repo-releases/</url>
@@ -140,9 +144,9 @@
     </dependency>
 
     <!-- additional data formats -->
-    
+
     <!-- CARBONDATA: uncomment the following dependencies to add support  -->
-    
+
     <!-- <dependency> -->
     <!--   <groupId>org.apache.carbondata</groupId> -->
     <!--   <artifactId>carbondata-parent</artifactId> -->
@@ -156,7 +160,7 @@
     <!-- </dependency> -->
 
     <!-- KUDU: uncomment the following dependencies to add support -->
-    
+
     <!-- <dependency> -->
     <!--   <groupId>org.apache.kudu</groupId> -->
     <!--   <artifactId>kudu-client</artifactId> -->
@@ -178,7 +182,8 @@
     <scala.binary.version>2.11</scala.binary.version>
 
     <spark.version>2.1.0</spark.version>
-    <hadoop.version>2.6.0</hadoop.version>
+    <hadoop.version>2.7.3</hadoop.version>
+    <yarn.version>2.7.3</yarn.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
@@ -247,7 +252,8 @@
         </executions>
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
-          <recompileMode>incremental</recompileMode>
+          <!--TODO fix me -->
+          <!--<recompileMode>incremental</recompileMode>-->
           <useZincServer>true</useZincServer>
           <args>
             <arg>-unchecked</arg>

--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -76,9 +76,13 @@ object JuliaRDD extends Logging {
 
       // Create and start the worker
       val juliaHome = sys.env.get("JULIA_HOME").getOrElse("")
+      val juliaVersion = sys.env.get("JULIA_VERSION").getOrElse("v0.5")
       val juliaCommand = Paths.get(juliaHome, "julia").toString()
-      //TODO read julia command path from env variable
-      val juliaPkgDir = Process(juliaCommand + " -e println(Pkg.dir(\"Spark\"))").!!.trim
+      val juliaPkgDir =  sys.env.get("JULIA_PKGDIR") match {
+          case Some(i) => Paths.get(i, juliaVersion, "Spark").toString()
+          case None => Process(juliaCommand + " -e println(Pkg.dir(\"Spark\"))").!!.trim
+      }
+
       val pb = new ProcessBuilder(juliaCommand, Paths.get(juliaPkgDir, "src", "worker_runner.jl").toString())
 
 

--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -7,12 +7,12 @@ import java.nio.file.Paths
 
 import org.apache.commons.compress.utils.Charsets
 import org.apache.spark._
-import org.apache.spark.api.java.{JavaSparkContext, JavaRDD, JavaPairRDD}
+import org.apache.spark.api.java.{JavaPairRDD, JavaRDD, JavaSparkContext}
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 
 import scala.collection.JavaConversions._
 import scala.language.existentials
-import org.apache.spark.internal.Logging
 import scala.reflect.ClassTag
 
 class AbstractJuliaRDD[T:ClassTag](
@@ -75,8 +75,13 @@ object JuliaRDD extends Logging {
       serverSocket = new ServerSocket(0, 1, InetAddress.getByAddress(Array(127, 0, 0, 1).map(_.toByte)))
 
       // Create and start the worker
-      val juliaPkgDir = Process("julia -e println(Pkg.dir(\"Spark\"))").!!.trim
-      val pb = new ProcessBuilder("julia", Paths.get(juliaPkgDir, "src", "worker_runner.jl").toString())
+      val juliaHome = sys.env.get("JULIA_HOME").getOrElse("")
+      val juliaCommand = Paths.get(juliaHome, "julia").toString()
+      //TODO read julia command path from env variable
+      val juliaPkgDir = Process(juliaCommand + " -e println(Pkg.dir(\"Spark\"))").!!.trim
+      val pb = new ProcessBuilder(juliaCommand, Paths.get(juliaPkgDir, "src", "worker_runner.jl").toString())
+
+
       pb.directory(new File(SparkFiles.getRootDirectory()))
       // val workerEnv = pb.environment()
       // workerEnv.putAll(envVars)

--- a/src/config.jl
+++ b/src/config.jl
@@ -4,8 +4,12 @@ type SparkConf
 end
 
 function SparkConf(;opts...)
-    jconf = JSparkConf(())
     opts = Dict(opts)
+    return SparkConf(opts)
+end
+
+function SparkConf(opts::Dict)
+    jconf = JSparkConf(())
     for (k, v) in opts
         jcall(jconf, "set", JSparkConf, (JString, JString), string(k), v)
     end
@@ -40,4 +44,8 @@ end
 
 function setappname(conf::SparkConf, appname::AbstractString)
     jcall(conf.jconf, "setAppName", JSparkConf, (JString,), appname)
+end
+
+function setdeploy(conf::SparkConf, deploymode::AbstractString)
+    jcall(conf.jconf, "set", JSparkConf, (JString, JString), "deploy-mode", deploymode)
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -15,10 +15,12 @@ Params:
  * appname - name of application
 """
 function SparkContext(;master::AbstractString="local",
+                      deploymode::AbstractString="client",
                       appname::AbstractString="Julia App on Spark",
-                      conf::SparkConf=SparkConf())
+                      conf::SparkConf=SparkConf(SPARK_DEFAULT_PROPS))
     setmaster(conf, master)
     setappname(conf, appname)
+    setdeploy(conf, deploymode)
     jsc = JJavaSparkContext((JSparkConf,), conf.jconf)
     sc = SparkContext(jsc, master, appname, "")
     add_jar(sc, joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1.jar"))

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,12 +1,68 @@
+global const SPARK_DEFAULT_PROPS = Dict()
 
 function init()
-    envcp = get(ENV, "CLASSPATH", "")
-    sparkjlassembly = joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1-assembly.jar")
-    classpath = @static is_windows() ? "$envcp;$sparkjlassembly" : "$envcp:$sparkjlassembly"
-    try
-        # prevent exceptions in REPL on code reloading
-        JavaCall.init(["-ea", "-Xmx1024M", "-Djava.class.path=$classpath"])
+    JavaCall.addClassPath(get(ENV, "CLASSPATH", ""))
+    defaults = load_spark_defaults(SPARK_DEFAULT_PROPS)
+    shome =  get(ENV, "SPARK_HOME", "")
+    if !isempty(shome)
+        for x in readdir(joinpath(shome, "jars"))
+            JavaCall.addClassPath(joinpath(shome, "jars", x))
+        end
+        JavaCall.addClassPath(joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1.jar"))
+    else
+        JavaCall.addClassPath(joinpath(dirname(@__FILE__), "..", "jvm", "sparkjl", "target", "sparkjl-0.1-assembly.jar"))
     end
+    for y in split(get(ENV, "SPARK_DIST_CLASSPATH", ""), [':',';'], keep=false)
+        JavaCall.addClassPath(String(y))
+    end
+    for z in split(get(defaults, "spark.driver.extraClassPath", ""), [':',';'], keep=false)
+        JavaCall.addClassPath(String(z))
+    end
+    JavaCall.addClassPath(get(ENV, "HADOOP_CONF_DIR", ""))
+    JavaCall.addClassPath(get(ENV, "YARN_CONF_DIR", ""))
+    if get(ENV, "HDP_VERSION", "") == ""
+       try
+           ENV["HDP_VERSION"] = pipeline(`hdp-select status` , `grep spark2-client` , `awk -F " " '{print $3}'`) |> readstring |> strip
+       catch
+       end
+    end
+
+    for y in split(get(defaults, "spark.driver.extraJavaOptions", ""), " ", keep=false)
+        JavaCall.addOpts(String(y))
+    end
+    s = get(defaults, "spark.driver.extraLibraryPath", "")
+    try
+        JavaCall.addOpts("-Djava.library.path=$(defaults["spark.driver.extraLibraryPath"])")
+    catch; end
+    JavaCall.addOpts("-ea")
+    JavaCall.addOpts("-Xmx1024M")
+    try
+        println("JVM starting from init.jl")
+        # prevent exceptions in REPL on code reloading
+
+        # JVM start in debug mode
+        #JavaCall.init(["-ea", "-Xmx1024M", "-Djava.class.path=$classpath", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000"])
+
+        #JVM default start
+        JavaCall.init()
+    end
+end
+
+function load_spark_defaults(d::Dict)
+    sconf = get(ENV, "SPARK_CONF", "")
+    if sconf == ""
+        shome =  get(ENV, "SPARK_HOME", "")
+        if shome == "" ; return d; end
+        sconf = joinpath(shome, "conf")
+    end
+    p = split(readstring(joinpath(sconf, "spark-defaults.conf")), '\n', keep=false)
+    for x in p
+         if !startswith(x, "#") && !isempty(strip(x))
+             y=split(x, " ", limit=2)
+             d[y[1]]=strip(y[2])
+         end
+    end
+    return d
 end
 
 init()

--- a/src/init.jl
+++ b/src/init.jl
@@ -37,13 +37,6 @@ function init()
     JavaCall.addOpts("-ea")
     JavaCall.addOpts("-Xmx1024M")
     try
-        println("JVM starting from init.jl")
-        # prevent exceptions in REPL on code reloading
-
-        # JVM start in debug mode
-        #JavaCall.init(["-ea", "-Xmx1024M", "-Djava.class.path=$classpath", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000"])
-
-        #JVM default start
         JavaCall.init()
     end
 end


### PR DESCRIPTION
This PR enables `yarn-client` mode in Spark. This mode is accessed by

 `sc = SparContext(master="yarn")`

Internally, this is simply a matter of loading the correct set of properties from `spark-defaults.conf`.  Since yarn manages the entire application, we do not add the Spark classes to the classpath. We only add Julia binding jar. 

This has been tested on Amazon EMR and Azure HDInsight, both of which rely on `yarn` as the cluster manager. 

Local mode remains the same, the classes are picked up from the _uber_ jar built within the julia package