### PR TITLE
Fix for large RDD

### DIFF
--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/JuliaRDD.scala
@@ -219,16 +219,20 @@ object JuliaRDD extends Logging {
     rdd1.cartesian(rdd2)
   }
 
-  def collectToByteArray[T](javaCollected: java.util.List[T]): Array[Byte] = {
-    val byteArrayOut = new ByteArrayOutputStream()
-    val dataStream = new DataOutputStream(byteArrayOut)
-    writeValueToStream(javaCollected, dataStream)
-    dataStream.flush()
-    byteArrayOut.toByteArray()
+  def collectToJulia(rdd: JavaRDD[Any]): Array[Byte] = {
+    writeToByteArray[java.util.List[Any]](rdd.collect())
   }
 
-  def collectToJulia(rdd: JavaRDD[Any]): Array[Byte] = {
-    collectToByteArray[Any](rdd.collect())
+  def collectToJuliaItr(rdd: JavaRDD[Any]): java.util.List[Any] = {
+    return rdd.collect()
+  }
+
+  def writeToByteArray[T](obj: Any): Array[Byte] = {
+    val byteArrayOut = new ByteArrayOutputStream()
+    val dataStream = new DataOutputStream(byteArrayOut)
+    writeValueToStream(obj, dataStream)
+    dataStream.flush()
+    byteArrayOut.toByteArray()
   }
 }
 
@@ -244,6 +248,10 @@ object JuliaPairRDD extends Logging {
     new JuliaPairRDD(rdd, command)
 
   def collectToJulia(rdd: JavaPairRDD[Any, Any]): Array[Byte] = {
-    JuliaRDD.collectToByteArray[(Any, Any)](rdd.collect())
+    JuliaRDD.writeToByteArray[java.util.List[(Any, Any)]](rdd.collect())
+  }
+
+  def collectToJuliaItr(rdd: JavaPairRDD[Any, Any]): java.util.List[(Any, Any)] = {
+    return rdd.collect()
   }
 }

--- a/src/rdd.jl
+++ b/src/rdd.jl
@@ -31,6 +31,25 @@ type PipelinedPairRDD <: PairRDD
     jrdd::JJuliaPairRDD
 end
 
+type RDDIterator
+    itr::JavaObject{Symbol("java.util.Iterator")}
+    l::jint
+end
+
+Base.start(x::RDDIterator) = start(x.itr)
+Base.done(x::RDDIterator, state) = done(x.itr, state)
+function Base.next(x::RDDIterator, state)
+    s = next(x.itr, state)
+    b = jcall(Spark.JJuliaRDD, "writeToByteArray", Vector{jbyte}, (JObject,), s[1])
+    b=reinterpret(Vector{UInt8}, b)
+    return readobj(IOBuffer(b))[2], true
+end
+
+Base.iteratorsize(::Type{RDDIterator}) = Base.HasLength()
+Base.length(x::RDDIterator) = x.l
+Base.iteratoreltype(::Type{RDDIterator}) = Base.EltypeUnknown()
+
+
 """
 Params:
  * parentrdd - parent RDD
@@ -192,6 +211,7 @@ function reduce(rdd::RDD, f::Function)
     process_attachments(context(rdd))
     locally_reduced = map_partitions(rdd, it->reduction_function(f, it))
     subresults = collect(locally_reduced)
+    subresults = collect_itr(locally_reduced)
     return reduce(f, subresults)
 end
 
@@ -211,6 +231,8 @@ function context(rdd::RDD)
     return SparkContext(jsc)
 end
 
+"""Collects the RDD to the Julia process, by serialising all values
+via a byte array"""
 function collect_internal(rdd::RDD, static_java_class, result_class)
     process_attachments(context(rdd))
     jbyte_arr = jcall(static_java_class, "collectToJulia", Vector{jbyte},
@@ -222,11 +244,39 @@ function collect_internal(rdd::RDD, static_java_class, result_class)
     return val
 end
 
+"""Collects the RDD to the Julia process, via an Julia iterator
+that fetches each row at a time. This prevents creation of a byte
+array containing all rows at a time."""
+function collect_internal_itr(rdd::RDD, static_java_class, result_class)
+    process_attachments(context(rdd))
+    lst = jcall(static_java_class, "collectToJuliaItr", @jimport(java.util.List),
+                 (result_class,),
+                 as_java_rdd(rdd))
+    itr = jcall(lst, "iterator", @jimport(java.util.Iterator), ())
+    l = jcall(lst, "size", jint, ())
+    return RDDIterator(itr, l)
+end
+
+
 """
 Collect all elements of `rdd` on a driver machine
 """
 function collect(rdd::SingleRDD)
     collect_internal(rdd, JJuliaRDD, JJavaRDD)
+end
+
+"""
+Collect all elements of `rdd` on a driver machine
+"""
+function collect_itr(rdd::PairRDD)
+    collect_internal_itr(rdd, JJuliaPairRDD, JJavaPairRDD)
+end
+
+"""
+Collect all elements of `rdd` on a driver machine
+"""
+function collect_itr(rdd::SingleRDD)
+    collect_internal_itr(rdd, JJuliaRDD, JJavaRDD)
 end
 
 """


### PR DESCRIPTION
When a RDD is reduced, the reduce is run on each partition, and then one row per partition is brought to the master and locally reduced. This last step causes the rows to be serialised from Scala to Julia.  This serialisation copies all the rows into a single Java ByteArray. 

All Java arrays are indexed by 32 bit integers, and thus a Java ByteArray has a limit of 2GB limit for storage. Hence, whenever the size of a single RDD row multiplied by the number of partitions is larger than 2GB, the serialisation, and hence the `collect` fails. 

This PR changes the code to serialise the RDD rows one at a time, via a custom `Iterator`. Since reduce only needs to operate on 2 rows at a time, this works well. There is a minor performance improvement as well. 

This still leaves a fundamental limit of 2GB for each row in an RDD. Larger rows will likely break in many places, so that is something we might have to just live with. 