### PR TITLE
Do not initialise the JVM by default Fix #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This will download and build all Julia and Java dependencies. To use Spark.jl ty
 
 ```julia
 using Spark
+Spark.init()
 ```
 
 ## RDD Interface: Examples

--- a/src/init.jl
+++ b/src/init.jl
@@ -8,5 +8,3 @@ function init()
         JavaCall.init(["-ea", "-Xmx1024M", "-Djava.class.path=$classpath"])
     end
 end
-
-init()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Spark
 
 using Base.Test
 
+Spark.init()
+
 include("basic.jl")
 include("map.jl")
 include("map_partitions.jl")


### PR DESCRIPTION
The workers load the Spark module, and do not need the JVM loaded on there. This PR changes the initialisation from default to user initiated. This improves the memory usage and start time on the workers. 