### PR TITLE
Remove OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.5
   - 0.6


### PR DESCRIPTION
Given Travis' travails with OSX builds (https://blog.travis-ci.com/2017-09-22-macos-update), it probably makes sense to remove OSX testing on automated builds. 

We don't really have much OSX specific issues or risk, do we? I'll keep testing JavaCall on OSX. 