### PR TITLE
Use Base.invokelatest to update world age, also make a generator version

### DIFF
--- a/src/worker_runner.jl
+++ b/src/worker_runner.jl
@@ -22,7 +22,7 @@ function main()
         split = readint(sock)
         func = readobj(sock)[2]
         itc = load_stream(sock)             # return chain representing partition iterator
-        dump_stream(sock, func(split, itc))
+        dump_stream(sock, Base.invokelatest(func,split, itc))
         writeint(sock, END_OF_DATA_SECTION)
         writeint(sock, END_OF_STREAM)
     catch e

--- a/test/julian_versions.jl
+++ b/test/julian_versions.jl
@@ -14,7 +14,7 @@
     @test (map_partitions(rdd, f) |> collect ==
            map_partitions(f, rdd) |> collect)
 
-    f = prt -> ((x, 1) for x in prt)
+    f = prt -> Base.invokelatest((x, 1) for x in prt)
     @test (map_partitions_pair(rdd, f) |> collect ==
            map_partitions_pair(f, rdd) |> collect)
 


### PR DESCRIPTION
I went ahead and propagated `Base.invokelatest` through rdd.jl. I now have tests passing on my machine for Julia v1.5 on JDK 8