### PR TITLE
Check that Java is of version 1.8

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -35,6 +35,7 @@ const JList = @jimport java.util.List
 const JMap = @jimport java.util.Map
 const JArrayList = @jimport java.util.ArrayList
 const JHashMap = @jimport java.util.HashMap
+const JSystem = @jimport java.lang.System
 
 include("init.jl")
 include("serialization.jl")

--- a/src/init.jl
+++ b/src/init.jl
@@ -37,6 +37,15 @@ function init()
     JavaCall.addOpts("-ea")
     JavaCall.addOpts("-Xmx1024M")
     JavaCall.init()
+
+    validateJavaVersion()
+end
+
+function validateJavaVersion()
+    version::String = jcall(JSystem, "getProperty", JString, (JString,), "java.version")
+    if !startswith(version, "1.8")
+        @warn "Java 1.8 is recommended for Spark.jl, but Java $version was used."
+    end
 end
 
 function load_spark_defaults(d::Dict)


### PR DESCRIPTION
Since Spark has problems running on newer Java version.
Even though it should work on 11, it is problematic with Spark.jl and
I don't know why...

This is only a warning, so it should not prevent anyone from running it on Java 11 (or other), but it may give clues if it runs into StackOverflowException or something inaccessible error