### PR TITLE
Arrow communication for Dataset collect and create 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,8 @@ uuid = "e3819d11-95af-5eea-9727-70c091663a01"
 version = "0.5.1"
 
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
 JavaCall = "494afd89-becb-516b-aafa-70d2670c0337"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,7 +7,7 @@ catch
     error("Cannot find maven. Is it installed?")
 end
 
-SPARK_VERSION = get(ENV, "BUILD_SPARK_VERSION", "2.4.6")
+SPARK_VERSION = get(ENV, "BUILD_SPARK_VERSION", "3.1.1")
 SCALA_VERSION = get(ENV, "BUILD_SCALA_VERSION", "2.12.11")
 SCALA_BINARY_VERSION = match(r"^\d+\.\d+", SCALA_VERSION).match
 

--- a/jvm/sparkjl/pom.xml
+++ b/jvm/sparkjl/pom.xml
@@ -192,7 +192,7 @@
     <scala.version>2.12.11</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
 
-    <spark.version>[2.4.6,3.1.1]</spark.version>
+    <spark.version>[3.0.0,3.1.1]</spark.version>
     <hadoop.version>2.7.3</hadoop.version>
     <yarn.version>2.7.3</yarn.version>
 

--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
@@ -1,0 +1,157 @@
+package org.apache.spark.sql.julia
+
+import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
+import org.apache.arrow.vector.{FieldVector, TimeStampMicroTZVector, TimeStampMilliTZVector, TimeStampVector, VarCharVector, VectorSchemaRoot}
+import org.apache.arrow.vector.ipc.message.MessageChannelReader
+import org.apache.arrow.vector.ipc.{ArrowFileReader, ArrowStreamReader, ArrowStreamWriter}
+import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
+import org.apache.commons.io.output.ByteArrayOutputStream
+import org.apache.spark.network.util.ByteArrayReadableChannel
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.{ExplainMode, SQLExecution}
+import org.apache.spark.sql.execution.arrow.{ArrowConverters, ArrowWriter}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnVector, ColumnarBatch}
+import org.apache.spark.util.Utils
+
+import java.sql.Timestamp
+import java.time.Instant
+import scala.collection.JavaConverters._
+
+object DatasetUtils {
+  // df.explain prints the plan to standard output
+  def explain[R](df: Dataset[R], mode: String): String =
+    df.queryExecution.explainString(ExplainMode.fromString(mode))
+  def collectToArrow[R](df: Dataset[R]): Array[Byte] = {
+    // TODO: see df.collectAsArrowToR() and collectAsArrowToPython, we should probably do something similar
+    val rows = SQLExecution.withNewExecutionId(df.queryExecution, Some("collectToArrow")) {
+      df.queryExecution.executedPlan.resetMetrics()
+      df.queryExecution.executedPlan.executeCollect()
+    }
+
+    val timeZone = df.sqlContext.conf.sessionLocalTimeZone
+    val arrowSchema = ArrowUtils.toArrowSchema(df.schema, timeZone)
+
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator(s"Julia collectToArrow", 0, Long.MaxValue)
+    val root = VectorSchemaRoot.create(arrowSchema, allocator)
+
+    Utils.tryWithSafeFinally {
+      val outStream = new ByteArrayOutputStream()
+      val arrowWriter = ArrowWriter.create(root)
+      val writer = new ArrowStreamWriter(root, null, outStream)
+      writer.start()
+
+      for (row <- rows) {
+        arrowWriter.write(row)
+      }
+      arrowWriter.finish()
+      writer.writeBatch()
+      arrowWriter.reset()
+      writer.end()
+
+      outStream.toByteArray
+    } {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  def fromArrow(sess: SparkSession, bytes: Array[Byte]): DataFrame = {
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator(s"Julia fromArrow", 0, Long.MaxValue)
+    //val reader = new ArrowFileReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
+    val reader = new ArrowStreamReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
+    val root = reader.getVectorSchemaRoot
+    try {
+      val schema = ArrowUtils.fromArrowSchema(root.getSchema)
+//      val vectors = root.getFieldVectors.asScala.toArray
+
+      // probably not the most efficient way to copy Arrow data into dataframe, but should work
+      // it would be nicer to use spark utils that convert Arrow directly to DataFrame
+      // see ArrowConverters.fromBatchIterator, but that returns InternalRow :/
+//      val readRows = new java.util.ArrayList[Row]()
+//      while (reader.loadNextBatch()) {
+//        val numRows = root.getRowCount
+//        val loadedVectors = vectors.zip(schema.fields).map {
+//          case (v, f) => readVector(v, f.dataType, 0, numRows)
+//        }
+//        for (i <- 0 until numRows)
+//          readRows.add(Row(loadedVectors.map(_(i)): _*))
+//      }
+//      val df = sess.createDataFrame(readRows, schema)
+//      val rowsCopy = df.collect()
+//      assert(rowsCopy.length == readRows.size)
+//      df
+
+      val batches = ArrowConverters.getBatchesFromStream(new ByteArrayReadableSeekableByteChannel(bytes)).toArray
+      ArrowConverters.toDataFrame(
+        sess.sparkContext.parallelize(batches.toSeq, batches.length).toJavaRDD(),
+        schema.json,
+        sess.sqlContext
+      )
+    } finally {
+      reader.close()
+      root.close()
+      allocator.close()
+    }
+  }
+
+  private def readVector(vector: FieldVector, dataType: DataType, start: Int, end: Int): Array[Any] = {
+    if (start == end)
+      return Array.empty
+    val result = new Array[Any](end - start)
+    vector match {
+      case mapVector: MapVector =>
+        val mapType = dataType.asInstanceOf[MapType]
+        val entries = mapVector.getDataVector.asInstanceOf[StructVector]
+        val keyVector = entries.getChild(MapVector.KEY_NAME)
+        val valueVector = entries.getChild(MapVector.VALUE_NAME)
+        for (i <- start until end) {
+          val elStart = mapVector.getElementStartIndex(i)
+          val elEnd = mapVector.getElementEndIndex(i)
+          val keys = readVector(keyVector, mapType.keyType, elStart, elEnd)
+          val values = readVector(valueVector, mapType.valueType, elStart, elEnd)
+          result(i - start) = keys.zip(values).toMap
+        }
+
+      case listVector: ListVector =>
+        val arrayType = dataType.asInstanceOf[ArrayType]
+        for (i <- start until end)
+          if (!listVector.isNull(i))
+            result(i - start) = readVector(
+              listVector.getDataVector,
+              arrayType.elementType,
+              listVector.getElementStartIndex(i),
+              listVector.getElementEndIndex(i)
+            )
+      case timeVector: TimeStampMilliTZVector =>
+        for (i <- start until end)
+          if (!timeVector.isNull(i))
+            result(i - start) = Instant.ofEpochMilli(i)
+      case timeVector: TimeStampMicroTZVector =>
+        for (i <- start until end)
+          if (!timeVector.isNull(i)) {
+            result(i - start) = Instant.ofEpochSecond(i)
+          }
+      case structVector: StructVector =>
+        val structType = dataType.asInstanceOf[StructType]
+        val fieldVectors = structType.fields.map(f =>
+          readVector(
+            structVector.getChild(f.name),
+            f.dataType,
+            start,
+            end
+          ))
+        fieldVectors.transpose.map(Row(_))
+      case stringVector: VarCharVector =>
+        for (i <- start until end)
+          result(i - start) = stringVector.getObject(i).toString
+      case _ =>
+        for (i <- start until end)
+          result(i - start) = vector.getObject(i)
+    }
+    result
+  }
+}

--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
@@ -1,25 +1,13 @@
 package org.apache.spark.sql.julia
 
-import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
-import org.apache.arrow.vector.{FieldVector, TimeStampMicroTZVector, TimeStampMilliTZVector, TimeStampVector, VarCharVector, VectorSchemaRoot}
-import org.apache.arrow.vector.ipc.message.MessageChannelReader
-import org.apache.arrow.vector.ipc.{ArrowFileReader, ArrowStreamReader, ArrowStreamWriter}
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter}
 import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 import org.apache.commons.io.output.ByteArrayOutputStream
-import org.apache.spark.network.util.ByteArrayReadableChannel
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.execution.{ExplainMode, SQLExecution}
 import org.apache.spark.sql.execution.arrow.{ArrowConverters, ArrowWriter}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnVector, ColumnarBatch}
-import org.apache.spark.util.Utils
-
-import java.sql.Timestamp
-import java.time.Instant
-import scala.collection.JavaConverters._
 
 object DatasetUtils {
   // df.explain prints the plan to standard output
@@ -38,7 +26,7 @@ object DatasetUtils {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator(s"Julia collectToArrow", 0, Long.MaxValue)
     val root = VectorSchemaRoot.create(arrowSchema, allocator)
 
-    Utils.tryWithSafeFinally {
+    try {
       val outStream = new ByteArrayOutputStream()
       val arrowWriter = ArrowWriter.create(root)
       val writer = new ArrowStreamWriter(root, null, outStream)
@@ -53,7 +41,7 @@ object DatasetUtils {
       writer.end()
 
       outStream.toByteArray
-    } {
+    } finally {
       root.close()
       allocator.close()
     }
@@ -64,94 +52,18 @@ object DatasetUtils {
     //val reader = new ArrowFileReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
     val reader = new ArrowStreamReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
     val root = reader.getVectorSchemaRoot
-    try {
-      val schema = ArrowUtils.fromArrowSchema(root.getSchema)
-//      val vectors = root.getFieldVectors.asScala.toArray
-
-      // probably not the most efficient way to copy Arrow data into dataframe, but should work
-      // it would be nicer to use spark utils that convert Arrow directly to DataFrame
-      // see ArrowConverters.fromBatchIterator, but that returns InternalRow :/
-//      val readRows = new java.util.ArrayList[Row]()
-//      while (reader.loadNextBatch()) {
-//        val numRows = root.getRowCount
-//        val loadedVectors = vectors.zip(schema.fields).map {
-//          case (v, f) => readVector(v, f.dataType, 0, numRows)
-//        }
-//        for (i <- 0 until numRows)
-//          readRows.add(Row(loadedVectors.map(_(i)): _*))
-//      }
-//      val df = sess.createDataFrame(readRows, schema)
-//      val rowsCopy = df.collect()
-//      assert(rowsCopy.length == readRows.size)
-//      df
-
-      val batches = ArrowConverters.getBatchesFromStream(new ByteArrayReadableSeekableByteChannel(bytes)).toArray
-      ArrowConverters.toDataFrame(
-        sess.sparkContext.parallelize(batches.toSeq, batches.length).toJavaRDD(),
-        schema.json,
-        sess.sqlContext
-      )
+    val schema = try {
+      ArrowUtils.fromArrowSchema(root.getSchema)
     } finally {
       reader.close()
       root.close()
       allocator.close()
     }
-  }
-
-  private def readVector(vector: FieldVector, dataType: DataType, start: Int, end: Int): Array[Any] = {
-    if (start == end)
-      return Array.empty
-    val result = new Array[Any](end - start)
-    vector match {
-      case mapVector: MapVector =>
-        val mapType = dataType.asInstanceOf[MapType]
-        val entries = mapVector.getDataVector.asInstanceOf[StructVector]
-        val keyVector = entries.getChild(MapVector.KEY_NAME)
-        val valueVector = entries.getChild(MapVector.VALUE_NAME)
-        for (i <- start until end) {
-          val elStart = mapVector.getElementStartIndex(i)
-          val elEnd = mapVector.getElementEndIndex(i)
-          val keys = readVector(keyVector, mapType.keyType, elStart, elEnd)
-          val values = readVector(valueVector, mapType.valueType, elStart, elEnd)
-          result(i - start) = keys.zip(values).toMap
-        }
-
-      case listVector: ListVector =>
-        val arrayType = dataType.asInstanceOf[ArrayType]
-        for (i <- start until end)
-          if (!listVector.isNull(i))
-            result(i - start) = readVector(
-              listVector.getDataVector,
-              arrayType.elementType,
-              listVector.getElementStartIndex(i),
-              listVector.getElementEndIndex(i)
-            )
-      case timeVector: TimeStampMilliTZVector =>
-        for (i <- start until end)
-          if (!timeVector.isNull(i))
-            result(i - start) = Instant.ofEpochMilli(i)
-      case timeVector: TimeStampMicroTZVector =>
-        for (i <- start until end)
-          if (!timeVector.isNull(i)) {
-            result(i - start) = Instant.ofEpochSecond(i)
-          }
-      case structVector: StructVector =>
-        val structType = dataType.asInstanceOf[StructType]
-        val fieldVectors = structType.fields.map(f =>
-          readVector(
-            structVector.getChild(f.name),
-            f.dataType,
-            start,
-            end
-          ))
-        fieldVectors.transpose.map(Row(_))
-      case stringVector: VarCharVector =>
-        for (i <- start until end)
-          result(i - start) = stringVector.getObject(i).toString
-      case _ =>
-        for (i <- start until end)
-          result(i - start) = vector.getObject(i)
-    }
-    result
+    val batches = ArrowConverters.getBatchesFromStream(new ByteArrayReadableSeekableByteChannel(bytes)).toArray
+    ArrowConverters.toDataFrame(
+      sess.sparkContext.parallelize(batches.toSeq, batches.length).toJavaRDD(),
+      schema.json,
+      sess.sqlContext
+    )
   }
 }

--- a/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
+++ b/jvm/sparkjl/src/main/scala/org/apache/spark/api/julia/DatasetUtils.scala
@@ -1,19 +1,24 @@
 package org.apache.spark.sql.julia
 
 import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter}
+import org.apache.arrow.vector.ipc.{ArrowFileReader, ArrowFileWriter, ArrowStreamReader, ArrowStreamWriter, SeekableReadChannel}
 import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.execution.{ExplainMode, SQLExecution}
 import org.apache.spark.sql.execution.arrow.{ArrowConverters, ArrowWriter}
 import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.util.Utils
+
+import java.io.{File, FileInputStream}
+import java.nio.channels.FileChannel
+import java.nio.file.{OpenOption, Path, Paths, StandardOpenOption}
 
 object DatasetUtils {
   // df.explain prints the plan to standard output
   def explain[R](df: Dataset[R], mode: String): String =
     df.queryExecution.explainString(ExplainMode.fromString(mode))
-  def collectToArrow[R](df: Dataset[R]): Array[Byte] = {
+  def collectToArrow[R](df: Dataset[R], tempFilePath: String): Unit = {
     // TODO: see df.collectAsArrowToR() and collectAsArrowToPython, we should probably do something similar
     val rows = SQLExecution.withNewExecutionId(df.queryExecution, Some("collectToArrow")) {
       df.queryExecution.executedPlan.resetMetrics()
@@ -27,43 +32,47 @@ object DatasetUtils {
     val root = VectorSchemaRoot.create(arrowSchema, allocator)
 
     try {
-      val outStream = new ByteArrayOutputStream()
-      val arrowWriter = ArrowWriter.create(root)
-      val writer = new ArrowStreamWriter(root, null, outStream)
-      writer.start()
+      Utils.tryWithResource(FileChannel.open(Paths.get(tempFilePath), StandardOpenOption.WRITE)) { tempFile =>
+        val arrowWriter = ArrowWriter.create(root)
+        val writer = new ArrowFileWriter(root, null, tempFile)
+        writer.start()
 
-      for (row <- rows) {
-        arrowWriter.write(row)
+        for (row <- rows) {
+          arrowWriter.write(row)
+        }
+        arrowWriter.finish()
+        writer.writeBatch()
+        arrowWriter.reset()
+        writer.end()
       }
-      arrowWriter.finish()
-      writer.writeBatch()
-      arrowWriter.reset()
-      writer.end()
-
-      outStream.toByteArray
+    } catch {
+      case x: Throwable =>
+        x.printStackTrace()
+        throw x
     } finally {
       root.close()
       allocator.close()
     }
   }
 
-  def fromArrow(sess: SparkSession, bytes: Array[Byte]): DataFrame = {
-    val allocator = ArrowUtils.rootAllocator.newChildAllocator(s"Julia fromArrow", 0, Long.MaxValue)
-    //val reader = new ArrowFileReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
-    val reader = new ArrowStreamReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
-    val root = reader.getVectorSchemaRoot
-    val schema = try {
-      ArrowUtils.fromArrowSchema(root.getSchema)
-    } finally {
-      reader.close()
-      root.close()
-      allocator.close()
+  def fromArrow(sess: SparkSession, tempFilePath: String): DataFrame =
+    Utils.tryWithResource(FileChannel.open(Paths.get(tempFilePath))) { tempFile =>
+      val allocator = ArrowUtils.rootAllocator.newChildAllocator(s"Julia fromArrow", 0, Long.MaxValue)
+      val reader = new ArrowStreamReader(tempFile, allocator)
+      //val reader = new ArrowStreamReader(new ByteArrayReadableSeekableByteChannel(bytes), allocator)
+      val root = reader.getVectorSchemaRoot
+      try {
+        val schema = ArrowUtils.fromArrowSchema(root.getSchema)
+        val batches = ArrowConverters.getBatchesFromStream(tempFile).toArray
+        ArrowConverters.toDataFrame(
+          sess.sparkContext.parallelize(batches.toSeq, batches.length).toJavaRDD(),
+          schema.json,
+          sess.sqlContext
+        )
+      } finally {
+        reader.close()
+        root.close()
+        allocator.close()
+      }
     }
-    val batches = ArrowConverters.getBatchesFromStream(new ByteArrayReadableSeekableByteChannel(bytes)).toArray
-    ArrowConverters.toDataFrame(
-      sess.sparkContext.parallelize(batches.toSeq, batches.length).toJavaRDD(),
-      schema.json,
-      sess.sqlContext
-    )
-  }
 }

--- a/src/Spark.jl
+++ b/src/Spark.jl
@@ -16,6 +16,9 @@ export
     reduce,
     filter,
     collect,
+    collect_to_arrow,
+    collect_to_tuples,
+    collect_to_dataframe,
     count,
     id,
     num_partitions,
@@ -41,7 +44,14 @@ export
     read_parquet,
     write_parquet,
     read_df,
-    write_df
+    write_df,
+    checkpoint,
+    local_checkpoint,
+    to_json,
+    explain,
+    create_df,
+    create_or_replace_temp_view,
+    create_temp_view
     
     
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -29,6 +29,7 @@ const JJuliaRDD = @jimport org.apache.spark.api.julia.JuliaRDD
 const JJuliaPairRDD = @jimport org.apache.spark.api.julia.JuliaPairRDD
 # utils
 const JRDDUtils = @jimport org.apache.spark.api.julia.RDDUtils
+const JDatasetUtils = @jimport org.apache.spark.sql.julia.DatasetUtils
 # Java utils
 const JIterator = @jimport java.util.Iterator
 const JList = @jimport java.util.List

--- a/src/init.jl
+++ b/src/init.jl
@@ -36,6 +36,7 @@ function init()
     catch; end
     JavaCall.addOpts("-ea")
     JavaCall.addOpts("-Xmx1024M")
+    JavaCall.addOpts("--illegal-access=warn")
     JavaCall.init()
 
     validateJavaVersion()

--- a/src/sql.jl
+++ b/src/sql.jl
@@ -108,11 +108,17 @@ function Base.iterate(iter::DatasetIterator{T}, state=1) where {T}
     return nothing
 end
 
+function schema_ddl(ds::Dataset)
+    jschema = jcall(ds.jdf, "schema", JStructType, ())
+    jcall(jschema, "toDDL", JString, ())
+end
+
 function schema_string(ds::Dataset)
     jschema = jcall(ds.jdf, "schema", JStructType, ())
     jcall(jschema, "simpleString", JString, ())
 end
-show(ds::Dataset) = jcall(ds.jdf, "show", Nothing, ())
+show(ds::Dataset; numRows:: Int=20, truncate:: Bool=true) =
+    jcall(ds.jdf, "show", Nothing, (jint, jboolean), numRows, truncate)
 Base.show(io::IO, ds::Dataset) = print(io, "Dataset($(schema_string(ds)))")
 
 function Base.names(ds::Dataset)
@@ -165,13 +171,20 @@ end
 
 # generic dataframe reader/writer
 
-function read_df(sess::SparkSession, path::AbstractString=""; format=nothing, options=Dict())
+function read_df(sess::SparkSession, path::AbstractString="";
+    format=nothing,
+    schema=nothing,
+    options=Dict()
+)
     jreader = dataframe_reader(sess)
     if format != nothing
         jreader = jcall(jreader, "format", JDataFrameReader, (JString,), string(format))
     end
+    if schema != nothing
+        jreader = jcall(jreader, "schema", JDataFrameReader, (JString,), string(schema))
+    end
     for (k, v) in options
-        jreader = jcall(jreader, "option", JDataFrameReader, (JString, JString), string(k), v)
+        jreader = jcall(jreader, "option", JDataFrameReader, (JString, JString), string(k), string(v))
     end
     jds = path != "" ?
         jcall(jreader, "load", JDataset, (JString,), path) :
@@ -253,6 +266,20 @@ function cache(ds::Dataset)
     return Dataset(jds)
 end
 
+"Returns the content of the Dataset as a Dataset of JSON strings."
+function to_json(ds::Dataset)
+    jds = jcall(ds.jdf, "toJSON", JDataset, ())
+    Dataset(jds)
+end
+
+function checkpoint(ds::Dataset; eager::Bool = true)
+    jds = jcall(ds.jdf, "checkpoint", JDataset, (jboolean,), eager)
+    Dataset(jds)
+end
+function local_checkpoint(ds::Dataset; eager::Bool = true)
+    jds = jcall(ds.jdf, "localCheckpoint", JDataset, (jboolean,), eager)
+    Dataset(jds)
+end
 function collect(ds::Dataset)
     jrows = jcall(ds.jdf, "collectAsList", JList, ())
     data = Array{Any}(nothing, 0)
@@ -265,23 +292,82 @@ end
 
 
 
+"Returns the logical plans of the Dataset. Mode may be simple, extended, codegen, cost, or formatted"
+function explain_string(ds::Dataset, mode::AbstractString="simple")
+    jcall(JDatasetUtils, "explain", JString, (JDataset, JString,), ds.jdf, mode)
+end
+"Prints the logical plans to console of the Dataset. Mode may be simple, extended, codegen, cost, or formatted"
+function explain(ds::Dataset, mode::AbstractString="simple")
+    println(explain_string(ds, mode))
+end
+
+"""
+Returns the number of rows in the Dataset.
+```
+julia> Spark.range(sess, 0, 100) |> count
+100
+```
+"""
 function count(ds::Dataset)
     return jcall(ds.jdf, "count", jlong, ())
 end
 
+
+"""
+Returns a new Dataset by taking the first n rows.
+```
+julia> Spark.range(sess, 0, 888) |> Spark.limit(20) |> count
+20
+```
+"""
+function limit(ds::Dataset, count::Int32)
+    jds = jcall(ds.jdf, "limit", JDataset, (jint,), count)
+    Dataset(jds)
+end
+limit(count::Int32) = ds -> limit(ds, count)
 
 function sql(sess::SparkSession, str::AbstractString)
     jds = jcall(sess.jsess, "sql", JDataset, (JString,), str)
     return Dataset(jds)
 end
 
+"""
+Creates a Dataset with a single LongType column named id, containing elements in a range from start to stop (exclusive)
 
+```
+julia> Spark.range(sess, 0, 100) |> Spark.count
+100
+```
+"""
+function range(sess::SparkSession, start::Int, stop::Int; step::Int=1, num_partitions::Union{Integer,Nothing}=nothing)
+    if num_partitions === nothing
+        Dataset(jcall(sess.jsess, "range", JDataset, (jlong,jlong,jlong), start, stop, step))
+    else
+        Dataset(jcall(sess.jsess, "range", JDataset, (jlong,jlong,jlong,jlong), start, stop, step, num_partitions))
+    end
+end
+
+function table(sess::SparkSession, name::AbstractString)
+    Dataset(jcall(sess.jsess, "table", JDataset, (JString,), name))
+end
 create_temp_view(ds::Dataset, str::AbstractString) =
     jcall(ds.jdf, "createTempView", Nothing, (JString,), str)
+create_temp_view(str::AbstractString) =
+    ds -> create_temp_view(ds, str)
 
+"""
+```jl
+julia> create_temp_view(Spark.range(sess, 0, 100), "a")
 
+julia> Spark.range(sess, 0, 1000) |> create_or_replace_temp_view("a")
+
+julia> sql(sess, "select * from a where id % 3 == 0") |> Spark.count
+334
+"""
 create_or_replace_temp_view(ds::Dataset, str::AbstractString) =
     jcall(ds.jdf, "createOrReplaceTempView", Nothing, (JString,), str)
+create_or_replace_temp_view(str::AbstractString) =
+    ds -> create_or_replace_temp_view(ds, str)
 
 
 col(name::Union{String,Symbol}) =

--- a/src/sql.jl
+++ b/src/sql.jl
@@ -350,11 +350,11 @@ julia> Spark.range(sess, 0, 888) |> Spark.limit(20) |> count
 20
 ```
 """
-function limit(ds::Dataset, count::Int32)
+function limit(ds::Dataset, count::Integer)
     jds = jcall(ds.jdf, "limit", JDataset, (jint,), count)
     Dataset(jds)
 end
-limit(count::Int32) = ds -> limit(ds, count)
+limit(count::Integer) = ds -> limit(ds, count)
 
 
 """
@@ -474,6 +474,7 @@ function head(ds::Dataset)
         error("Dataset $ds is empty")
     else
         row[1]
+    end
 end
 
 

--- a/test/sql.jl
+++ b/test/sql.jl
@@ -67,7 +67,7 @@ describe_df = DataFrame(complexdata) |> create_df(sess) |> Spark.describe |> col
 @test describe_df.a[2] == "5000.0"
 
 @test Spark.range(sess, 0, 888) |> Spark.limit(20) |> count == 20
-@test sql(sess, "select 1 as a, array(1) as b") |> Spark.head == (a=1, b=[2])
+@test sql(sess, "select 1 as a, array(1) as b") |> Spark.head == (a=1, b=[Int32(1)])
 
 close(sess)
 

--- a/test/sql.jl
+++ b/test/sql.jl
@@ -26,12 +26,48 @@ ds_all = sql(sess, "SELECT * from people")
 
 @test Spark.explain_string(local_checkpoint(ds_all)) == "== Physical Plan ==\n*(1) Scan ExistingRDD[age#7L,name#8]\n\n"
 
-@test Spark.as_named_tuple(Spark.head(ds_all)) == (age = 32, name = "Peter")
+@test Spark.head(ds_all) == (age = 32, name = "Peter")
 
 # test conversion to DataFrames
 df = DataFrame(ds_all)
 @test nrow(df) == 2
 @test ncol(df) == 2
+
+# test Arrow conversions to/from DataFrames
+
+singlerowtable = collect_to_dataframe(sql(sess, "select 1 as a,'my_string' as b"))
+@test singlerowtable == DataFrame(a=[1], b=["my_string"])
+
+numbers = Spark.range(sess, 1, 10000) |> collect_to_dataframe
+@test length(numbers.id) == 9999
+
+create_or_replace_temp_view(create_df(sess, numbers), "numbers")
+
+@test count(Spark.table(sess, "numbers")) == 9999
+
+complexdata = sql(sess, """
+    select id as a,
+           id * 2 as b,
+           array(id + 1) as arr,
+           map('xxxxx', id, 'x', id) as m,
+           struct(string(id) as nn, id as n) as nested,
+           double(id/2.0) as dec
+    from numbers""") |> collect_to_tuples
+@test complexdata[1].a == 1
+@test complexdata[1].b == 2
+@test complexdata[1].arr == [2]
+@test complexdata[1].m == Dict("xxxxx" => 1, "x" => 1)
+@test complexdata[1].nested.nn == "1"
+@test complexdata[1].dec == 0.5
+
+describe_df = DataFrame(complexdata) |> create_df(sess) |> Spark.describe |> collect_to_dataframe
+
+@test describe_df.summary == ["count", "mean", "stddev", "min", "max"]
+@test describe_df.a[1] == "9999"
+@test describe_df.a[2] == "5000.0"
+
+@test Spark.range(sess, 0, 888) |> Spark.limit(20) |> count == 20
+@test sql(sess, "select 1 as a, array(1) as b") |> Spark.head == (a=1, b=[2])
 
 close(sess)
 

--- a/test/sql.jl
+++ b/test/sql.jl
@@ -24,6 +24,8 @@ end
 Spark.create_temp_view(ds, "people")
 ds_all = sql(sess, "SELECT * from people")
 
+@test Spark.explain_string(local_checkpoint(ds_all)) == "== Physical Plan ==\n*(1) Scan ExistingRDD[age#7L,name#8]\n\n"
+
 @test Spark.as_named_tuple(Spark.head(ds_all)) == (age = 32, name = "Peter")
 
 # test conversion to DataFrames


### PR DESCRIPTION
Function `collect_to_arrow` downloads the dataset as an Arrow table.
`collect_to_dataframe` convert the arrow table to julia DataFrame and
`collect_to_tuples` converts the Arrow table to a list of named tuples.

`create_df` takes a julia Table, transfers is to Spark using Arrow and creates new Dataset

Currently, the data is transferred by sending byte array through jcall, probably
not a very efficient way to it. I'd like to share memory between
Julia and the JVM, but I could not figure out how to do that.
Other alternatives are transferring using socket or by putting the data in
a temporary file.

I'd expect the temporary file to be faster, because we can use mmap to read/write it
(Arrow.jl does this by default). I'm not sure, but maybe it can even stay in memory
if we don't force it to be written to disk.

I looked into PySpark and they seem to use both network and file, depends on some flag: https://github.com/apache/spark/blob/master/python/pyspark/context.py#L594