### PR TITLE
Fix Base.read() in initialization that has been overwritten by Spark.read()

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,14 +11,14 @@ Spark.jl supports multiple cluster types (in client mode), and can be considered
 Spark.jl requires at least JDK 8/11 and Maven to be installed and available in PATH.
 
 ```julia
-Pkg.add("Spark.jl")
+] add Spark
 ```
 
 To link against a specific version of Spark, also run:
 
 ```julia
 ENV["BUILD_SPARK_VERSION"] = "3.2.1"   # version you need
-Pkg.build("Spark")
+] build Spark
 ```
 
 ### Quick Example

--- a/src/init.jl
+++ b/src/init.jl
@@ -83,7 +83,7 @@ function load_spark_defaults(d::Dict)
     else
         spark_defaults_conf = spark_defaults_locs[conf_idx]
     end
-    p = split(read(spark_defaults_conf, String), '\n', keepempty=false)
+    p = split(Base.read(spark_defaults_conf, String), '\n', keepempty=false)
     for x in p
          if !startswith(x, "#") && !isempty(strip(x))
              y=split(x, limit=2)


### PR DESCRIPTION
Fixes #106 