### PR TITLE
Update build.jl with SCALA_BINARY

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,7 +9,7 @@ end
 
 SPARK_VERSION = get(ENV, "BUILD_SPARK_VERSION", "3.2.1")
 SCALA_VERSION = get(ENV, "BUILD_SCALA_VERSION", "2.13")
-SCALA_BINARY_VERSION = get(ENV, "BUILD_SCALA_VERSION", "2.13.6")
+SCALA_BINARY_VERSION = get(ENV, "BUILD_SCALA_BINARY_VERSION", "2.13.6")
 
 cd(joinpath(dirname(@__DIR__), "jvm/sparkjl")) do
     run(`$mvn clean package -Dspark.version=$SPARK_VERSION -Dscala.version=$SCALA_VERSION -Dscala.binary.version=$SCALA_BINARY_VERSION`)

--- a/jvm/sparkjl/pom.xml
+++ b/jvm/sparkjl/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>InMemoryJavaCompiler</artifactId>
       <version>1.3.0</version>
     </dependency>
+    <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql-kafka-0-10_${scala.version}</artifactId>
+        <version>${spark.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Hello dfdx,

I came across quite a peculiar error when trying to submit jobs towards a standalone cluster in client mode. After a lot of testing I narrowed it down to incompatibility issues between Spark/Java/Scala versions (actual error was serialisation in RPC)
```
java.lang.RuntimeException: java.io.InvalidClassException: org.apache.spark.rpc.netty.RpcEndpointVerifier$CheckExistence; local class incompatible: stream classdesc serialVersionUID = 5378738997755484868, local class serialVersionUID = 7789290765573734431
```
when setting the SCALA_VERSION env-variable to e.g 2.12 or 2.12.17 (as required by latest spark-3.4.0 docker image) Maven breaks and cannot find the version requested. I managed to get everything working by manually setting the variables required in `Spark.jl/deps/build.jl` (that is patch version on the BINARY variable) and running the same code against the folder. 

I therefore would like to submit this PR to be able to influence also the `BUILD_SCALA_BINARY_VERSION` via env variables to also influence this.

PS. Maybe also consider mentioning these env variables in the README/docs would be helpful because I only found them by looking through the code.